### PR TITLE
add trigger environment variable

### DIFF
--- a/environ/environ.go
+++ b/environ/environ.go
@@ -141,6 +141,7 @@ func Build(build *drone.Build) map[string]string {
 		"DRONE_BUILD_FINISHED":       fmt.Sprint(build.Finished),
 		"DRONE_DEPLOY_TO":            build.Deploy,
 		"DRONE_DEPLOY_ID":            fmt.Sprint(build.DeployID),
+		"DRONE_BUILD_TRIGGER":        build.Trigger,
 
 		// these are legacy configuration parameters for backward
 		// compatibility with drone 0.8. These are deprecated and

--- a/environ/environ_test.go
+++ b/environ/environ_test.go
@@ -58,6 +58,7 @@ func TestRepo(t *testing.T) {
 
 func TestBuild(t *testing.T) {
 	v := &drone.Build{
+		Trigger:      "root",
 		Source:       "develop",
 		Target:       "master",
 		After:        "762941318ee16e59dabbacb1b4049eec22f0d303",
@@ -124,6 +125,7 @@ func TestBuild(t *testing.T) {
 		"DRONE_PULL_REQUEST":         "32",
 		"DRONE_SOURCE_BRANCH":        "develop",
 		"DRONE_TARGET_BRANCH":        "master",
+		"DRONE_BUILD_TRIGGER":        "root",
 
 		"CI_BUILD_CREATED":        "1561421740",
 		"CI_BUILD_EVENT":          "pull_request",


### PR DESCRIPTION
When the `Promote` event is triggered, it is expected that the trigger person can be obtained for further judgment