### PR TITLE
Properly print newline characters of shell scrips

### DIFF
--- a/shell/bash/bash.go
+++ b/shell/bash/bash.go
@@ -47,6 +47,6 @@ const optionScript = "set -e"
 // traceScript is a helper script that is added to
 // the build script to trace a command.
 const traceScript = `
-echo + %s
+echo -e %s | sed -e 's/^/+ /'
 %s
 `

--- a/shell/bash/bash_test.go
+++ b/shell/bash/bash_test.go
@@ -26,7 +26,7 @@ func TestCommands(t *testing.T) {
 }
 
 func TestScript(t *testing.T) {
-	got, want := Script([]string{"go build", "go test"}), exampleScript
+	got, want := Script([]string{"go build", "go test", "go build\ngo test"}), exampleScript
 	if got != want {
 		t.Errorf("Want %q, got %q", want, got)
 	}
@@ -35,9 +35,13 @@ func TestScript(t *testing.T) {
 var exampleScript = `
 set -e
 
-echo + "go build"
+echo -e "go build" | sed -e 's/^/+ /'
 go build
 
-echo + "go test"
+echo -e "go test" | sed -e 's/^/+ /'
+go test
+
+echo -e "go build\ngo test" | sed -e 's/^/+ /'
+go build
 go test
 `

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -28,7 +28,7 @@ func TestCommands(t *testing.T) {
 }
 
 func TestScript(t *testing.T) {
-	got, want := Script([]string{"go build", "go test"}), exampleScript
+	got, want := Script([]string{"go build", "go test", "go build\ngo test"}), exampleScript
 	if got != want {
 		t.Errorf("Want %q, got %q", want, got)
 	}
@@ -37,9 +37,13 @@ func TestScript(t *testing.T) {
 var exampleScript = `
 set -e
 
-echo + "go build"
+echo -e "go build" | sed -e 's/^/+ /'
 go build
 
-echo + "go test"
+echo -e "go test" | sed -e 's/^/+ /'
+go test
+
+echo -e "go build\ngo test" | sed -e 's/^/+ /'
+go build
 go test
 `


### PR DESCRIPTION
With this change, the shell now respects newlines in multiline commands.
A command like that:
```yaml
  commands:
    - |
      cd /app
      go test
      go build
```

Will now output this:
```
+ cd /app
+ go test
+ go build
```

Instead of
```
+ cd /app\ngo test\ngo build
```

To improve the compatibility, we might need to use
```bash
printf %s | sed -e 's/^/+ /' && echo
```
