### PR TITLE
feat: add a new environment for the title of PR.

### DIFF
--- a/environ/environ.go
+++ b/environ/environ.go
@@ -175,6 +175,7 @@ func Build(build *drone.Build) map[string]string {
 	}
 	if build.Event == drone.EventPullRequest {
 		env["DRONE_PULL_REQUEST"] = re.FindString(build.Ref)
+		env["DRONE_PULL_REQUEST_TITLE"] = build.Title
 	}
 	if strings.HasPrefix(build.Ref, "refs/tags/") {
 		tag := strings.TrimPrefix(build.Ref, "refs/tags/")

--- a/environ/environ_test.go
+++ b/environ/environ_test.go
@@ -64,6 +64,7 @@ func TestBuild(t *testing.T) {
 		Before:       "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
 		Ref:          "refs/pull/32/head",
 		Link:         "https://github.com/octocat/Hello-World/commit/762941318ee16e59dabbacb1b4049eec22f0d303",
+		Title:        "feat: update README",
 		Message:      "updated README",
 		Author:       "octocat",
 		AuthorAvatar: "https://avatars0.githubusercontent.com/u/583231",
@@ -122,6 +123,7 @@ func TestBuild(t *testing.T) {
 		"DRONE_DEPLOY_ID":            "235634642",
 		"DRONE_FAILED_STAGES":        "frontend",
 		"DRONE_PULL_REQUEST":         "32",
+		"DRONE_PULL_REQUEST_TITLE":   "feat: update README",
 		"DRONE_SOURCE_BRANCH":        "develop",
 		"DRONE_TARGET_BRANCH":        "master",
 


### PR DESCRIPTION
Hi, Drone.

I want to add a new environment `PULL_REQUEST_TITLE` which has the title of PR. It could be helpful for the [conventional commit lint](https://github.com/conventional-changelog/commitlint#benefits-using-commitlint) or [other use-cases](https://discourse.drone.io/t/drone-commit-message-on-pull-request-is-the-first-comment-instead-of-the-title-in-gitea/8916).