### PR TITLE
Add `image` clone option

### DIFF
--- a/manifest/clone.go
+++ b/manifest/clone.go
@@ -6,9 +6,10 @@ package manifest
 
 // Clone configures the git clone.
 type Clone struct {
-	Disable    bool `json:"disable,omitempty"`
-	Depth      int  `json:"depth,omitempty"`
-	Retries    int  `json:"retries,omitempty"`
-	SkipVerify bool `json:"skip_verify,omitempty" yaml:"skip_verify"`
-	Trace      bool `json:"trace,omitempty"`
+	Disable    bool   `json:"disable,omitempty"`
+	Depth      int    `json:"depth,omitempty"`
+	Retries    int    `json:"retries,omitempty"`
+	SkipVerify bool   `json:"skip_verify,omitempty" yaml:"skip_verify"`
+	Trace      bool   `json:"trace,omitempty"`
+	Image      string `json:"image,omitempty"`
 }


### PR DESCRIPTION
This will allow us to override the `drone/git` image which is currently broken for Windows and ARM